### PR TITLE
stop the server as part of an uninstall

### DIFF
--- a/mlvm.sh
+++ b/mlvm.sh
@@ -67,6 +67,7 @@ hasversion() {
 
 uninstall() {
   echo "Uninstalling conventional MarkLogic"
+  ~/Library/StartupItems/MarkLogic stop
   rm -fr ~/Library/MarkLogic
   rm -fr ~/Library/Application\ Support/MarkLogic
   rm -fr ~/Library/StartupItems/MarkLogic 


### PR DESCRIPTION
this fixes #10, by ensuring that the server is stopped before the install directories are removed
